### PR TITLE
Upgrade enacl to 1.1.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {plugins, [rebar3_hex]}.
-{deps, [{enacl, "0.17.2"}]}.
+{deps, [{enacl, "1.1.1"}]}.
 
 {profiles, [{test, [{deps, [{jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}}]}]}
            ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.1.0",
-[{<<"enacl">>,{pkg,<<"enacl">>,<<"0.17.2">>},0}]}.
+[{<<"enacl">>,{pkg,<<"enacl">>,<<"1.1.1">>},0}]}.
 [
 {pkg_hash,[
- {<<"enacl">>, <<"4AD59142943E72D72C56E33C30DEDEF28ADD8EBEE79C51033562B0CB4B93EDE0">>}]}
+ {<<"enacl">>, <<"F65DC64D9BFF2D8A534CB77AEF14DA5E7A2FA148987D87856F79A4745C9C2627">>}]}
 ].


### PR DESCRIPTION
upgrades enacl to 1.1.1. 

Only minor fixups required. 

@hanssv There _is_ a question around whether nonce should be a `binary()` by default instead of a `pos_integer()` but that would change the enoise API. It may be more consistent with what the underlying crypto engines requires though 

 